### PR TITLE
Fix crash when using with appcache package

### DIFF
--- a/client/iron-router-autoscroll.js
+++ b/client/iron-router-autoscroll.js
@@ -38,7 +38,9 @@ var scrollToTop = function () {
       if (backToPosition) {
         position = backToPosition;
         backToPosition = null;
-      } else if ($(hash).length) {
+        // Appcache package alters routes into hashes like `#!route` which is not valid jquery
+        // selector so the code crashed the app. So additional check for exclamation mark was added.
+      } else if (hash[1] !== '!' && $(hash).length) {
         position = $(hash).offset().top;
       }
       else {


### PR DESCRIPTION
Fixed an issue originally posted here: [iron-meteor/iron-router/issues/1331](https://github.com/iron-meteor/iron-router/issues/1331)

Quote from the sources:

> Appcache package alters routes into hashes like `#!route` which is not valid jquery selector so the code crashed the app. So additional check for exclamation mark was added.
