### PR TITLE
Fixed jQuery selector for target anchor

### DIFF
--- a/client/iron-router-autoscroll.js
+++ b/client/iron-router-autoscroll.js
@@ -30,16 +30,17 @@ var scrollToTop = function () {
   if (self.ready()) {
     // defer until after the DOM update so that the position can be correct
     Tracker.afterFlush(function () {
-      var hash = window.location.hash;
+      var hash = window.location.hash.substring(1);
       if(hash.indexOf('maintainScroll=1') > -1) return;
 
       var position;
+      var hashElement = $('a[name='+hash+']');
 
       if (backToPosition) {
         position = backToPosition;
         backToPosition = null;
-      } else if ($(hash).length) {
-        position = $(hash).offset().top;
+      } else if (hashElement.length) {
+        position = hashElement.offset().top;
       }
       else {
         position = 0;


### PR DESCRIPTION
I wasn't able to use the iron-router-autoscroll as is. While debugging I found that the jQuery selector never matched the valid element. Implemented these changes to make it work.
