### PR TITLE
0.0.10 - self-deprecates and implies router-autoscroll

### DIFF
--- a/iron-router-autoscroll-deprecated.js
+++ b/iron-router-autoscroll-deprecated.js
@@ -1,0 +1,7 @@
+Meteor.startup(function(){
+  console.log("okgrow:iron-router-autoscroll package is deprecated. Please use okgrow:router-autoscroll.")
+});
+
+if (Meteor.isClient){
+  IronRouterAutoscroll = RouterAutoscroll;
+}

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'okgrow:iron-router-autoscroll',
-  version: '0.0.9',
-  summary: 'Fixes page position after changing pages using Iron Router',
+  version: '0.0.11',
+  summary: 'Deprecated - pulls in okgrow:router-autoscroll',
   git: 'https://github.com/okgrow/iron-router-autoscroll',
   documentation: 'README.md'
 });
@@ -9,13 +9,11 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.0.3.1');
   api.use('iron:router@1.0.7', 'client', {weak: true});
-  api.addFiles('client/iron-router-autoscroll.js', 'client');
+  api.use('kadira:flow-router@2.4.0', 'client', {weak: true});
+  api.use('okgrow:router-autoscroll@0.0.12');
+  // the constant RouterAutoScroll is exported
+  api.imply('okgrow:router-autoscroll');
+  api.addFiles('iron-router-autoscroll-deprecated.js');
+  // also RouterAutoScroll is aliased to IronRouterAutoscroll and exported
   api.export('IronRouterAutoscroll');
 });
-
-// TODO
-// Package.onTest(function(api) {
-//   api.use('tinytest');
-//   api.use('iron-router-autoscroll');
-//   api.addFiles('test/iron-router-autoscroll-tests.js');
-// });


### PR DESCRIPTION
This PR:
- prints a deprecation warning when using this package
- implies `okgrow:router-autoscroll` and exports IronRouterAutoscroll for compatibility with the original

Package consumers should expect:
- client and server-side deprecation warnings
- all the functionality as before, plus any new functionality of `okgrow:router-autoscroll` 

The only atmosphere package listed as depending on it `telescope:lib`, has been notified to update its dependencies.

The example app used to test it is in: https://github.com/okgrow/router-autoscroll/tree/master/examples/deprecated-iron-router-example
